### PR TITLE
Introduce OnAccessExcludeProcessPath on-access configuration option.

### DIFF
--- a/docs/man/clamd.conf.5.in
+++ b/docs/man/clamd.conf.5.in
@@ -708,6 +708,11 @@ This option allows exclusions via user names when using the on-access scanning c
 .br
 Default: disabled
 .TP
+\fBOnAccessExcludeProcessPath STRING\fR
+This option allows exclusions via process executable path when using the on-access scanning client. It can be used multiple times, and has the same potential race condition limitations of the OnAccessExcludeUID option.
+.br
+Default: disabled
+.TP
 \fBOnAccessMaxFileSize SIZE\fR
 Files larger than this value will not be scanned in on access.
 .br

--- a/etc/clamd.conf.sample
+++ b/etc/clamd.conf.sample
@@ -748,6 +748,12 @@ Example
 # Default: disabled
 #OnAccessExcludeUname clamav
 
+# This option allows excluding processes from on-access scanning by its executable path.
+# It can be used multiple times.
+# Default: disabled
+#OnAccessExcludeProcessPath ^/bin/
+#OnAccessExcludeProcessPath ^/usr/local/bin/someapp
+
 # Number of times the OnAccess client will retry a failed scan due to
 # connection problems (or other issues).
 # Default: 0

--- a/shared/optparser.c
+++ b/shared/optparser.c
@@ -464,6 +464,8 @@ const struct clam_option __clam_options[] = {
 
     {"OnAccessExcludeUname", NULL, 0, CLOPT_TYPE_STRING, NULL, -1, NULL, FLAG_MULTIPLE, OPT_CLAMD, "This option allows exclusions via user names when using the on-access scanning client. It can\nbe used multiple times.", "clamuser"},
 
+    {"OnAccessExcludeProcessPath", NULL, 0, CLOPT_TYPE_STRING, NULL, -1, NULL, FLAG_MULTIPLE, OPT_CLAMD, "This option allows excluding processes from on-access scanning by its executable path.\nIt can be used multiple times.", "^/bin/\n^/usr/local/bin/someapp"},
+
     {"OnAccessMaxFileSize", NULL, 0, CLOPT_TYPE_SIZE, MATCH_SIZE, 5242880, NULL, 0, OPT_CLAMD, "Files larger than this value will not be scanned in on access.", "5M"},
 
     {"OnAccessDisableDDD", NULL, 0, CLOPT_TYPE_BOOL, MATCH_BOOL, 0, NULL, 0, OPT_CLAMD, "This option toggles the dynamic directory determination system for on-access scanning (Linux only).", "no"},


### PR DESCRIPTION
This option allows exclusions via process executable path when using the on-access scanning client.
It can be used multiple times(one per line), and has the same potential race condition limitations of the OnAccessExcludeUID option without OnAccessPrevention enabled. 
The option is disabled by default. 
Examples: 
- OnAccessExcludeProcessPath ^/bin/ 
- OnAccessExcludeProcessPath ^/usr/local/bin/someapp